### PR TITLE
Fix normal style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit-custom-styles",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "subversion": "1",
   "description": "CustomStyle plugin built with ProseMirror",
   "main": "dist/index.js",

--- a/src/CustomStyleCommand.js
+++ b/src/CustomStyleCommand.js
@@ -467,7 +467,7 @@ class CustomStyleCommand extends UICommand {
             endPos,
             val.styleName
           );
-          tr = applyStyle(val, val.styleName, state, tr);
+          tr = updateDocument(state, tr, val.styleName, val.styles);
           dispatch(tr);
         }
       });

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ import {
   getCustomStyleByLevel,
   setStyleRuntime,
   setHidenumberingFlag,
-  isStylesLoaded
+  isStylesLoaded,
+  setStyles,
 } from './customStyle';
 import { RESERVED_STYLE_NONE } from './CustomStyleNodeSpec';
 import { getLineSpacingValue } from '@modusoperandi/licit-ui-commands';
@@ -54,6 +55,8 @@ export class CustomstylePlugin extends Plugin {
         init(config, state) {
           loaded = false;
           firstTime = true;
+          setStyles([]);
+          // await setStyleRuntime(runtime, refreshToApplyStyles.bind(this));
           setStyleRuntime(runtime, refreshToApplyStyles.bind(this));
           setHidenumberingFlag(hideNumbering ? hideNumbering : false);
         },


### PR DESCRIPTION
1. Fix: Normal style font reset issue on document load
2. Fix: Image align to center for Normal style
3. Fix: Create a new style with a name that's already existing in the document, its not updating styles in the document.