### PR TITLE
Fixed UI issues in Style editor

### DIFF
--- a/src/CustomStyleCommand.ts
+++ b/src/CustomStyleCommand.ts
@@ -629,6 +629,7 @@ export class CustomStyleCommand extends UICommand {
       styles: {},
       // runtime: runtime,
       editorView: editorView,
+      theme: UICommand.theme,
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,7 +366,7 @@ function optimizedPasteHandler(slice1, prevState, nextState, csview, tr) {
 
   // STEP 4: Apply styles once per group instead of per node
   const opt = 1;
-  styleGroups.forEach((infos, key) => {
+  styleGroups.forEach((infos) => {
     const info = infos[0];
 
     if (info.hasParentAttrs) {
@@ -402,69 +402,6 @@ function optimizedPasteHandler(slice1, prevState, nextState, csview, tr) {
   return tr;
 }
 
-// ALTERNATIVE: Async processing for very large pastes
-function asyncPasteHandler(slice1, prevState, nextState, csview, tr) {
-  const CHUNK_SIZE = 10;
-  const chunks = [];
-
-  // Split into chunks
-  for (let i = 0; i < slice1.content.childCount; i += CHUNK_SIZE) {
-    chunks.push(slice1.content.content.slice(i, i + CHUNK_SIZE));
-  }
-
-  // Process first chunk immediately
-  // Schedule rest for later
-  setTimeout(() => {
-    // Process remaining chunks
-    // You'd need to dispatch a new transaction here
-  }, 0);
-
-  return tr;
-}
-
-// NEW: Apply styles in optimized batches
-function applyBatchedStyleUpdates(updates, nextState, tr, hasParentAttrs) {
-  const opt = 1;
-
-  // Group updates by style for potential optimization
-  const styleGroups = new Map();
-
-  for (const update of updates) {
-    if (hasParentAttrs) {
-      // Use applyStyleToEachNode for nodes with parent attrs
-      const styleProp = getCustomStyleByName(update.styleName);
-      tr = applyStyleToEachNode(
-        nextState,
-        update.pos,
-        update.endPos,
-        tr,
-        styleProp,
-        update.styleName
-      );
-    } else {
-      // Apply latest style
-      tr = applyLatestStyle(
-        update.styleName ?? '',
-        nextState,
-        tr,
-        update.node,
-        update.pos,
-        update.endPos,
-        null,
-        opt
-      );
-
-      // Set node markup if needed
-      if (update.needsMarkup) {
-        const newattrs = { ...update.node.attrs };
-        newattrs.styleName = update.styleName;
-        tr = tr.setNodeMarkup(update.pos, undefined, newattrs);
-      }
-    }
-  }
-
-  return tr;
-}
 //LIC-254 Create new line by placing cursor at the beginning of a paragraph applies the current style instead of Normal style
 export function applyStyleForPreviousEmptyParagraph(
   nextState: EditorState,

--- a/src/ui/CustomMenuUI.tsx
+++ b/src/ui/CustomMenuUI.tsx
@@ -50,6 +50,7 @@ export class CustomMenuUI extends React.PureComponent<any, any> {
       left: '',
     },
   };
+  theme = null;
 
   render() {
     const { dispatch, editorState, editorView, staticCommand, onCommand } =
@@ -59,6 +60,7 @@ export class CustomMenuUI extends React.PureComponent<any, any> {
     let counter = 0;
     let selecteClassName = '';
     const theme = this.props.theme;
+    this.theme =  this.props.theme;
     const selectedName = this.getTheSelectedCustomStyle(this.props.editorState);
     const commandGroups_nw = this.getCommandGroups();
     commandGroups_nw.forEach((group) => {
@@ -306,6 +308,7 @@ export class CustomMenuUI extends React.PureComponent<any, any> {
         description: command._customStyle.description,
         styles: command._customStyle.styles,
         editorView: this.props.editorView,
+        theme:this.theme,
       },
       {
         position: atViewportCenter,

--- a/src/ui/CustomStyleEditor.tsx
+++ b/src/ui/CustomStyleEditor.tsx
@@ -1232,7 +1232,6 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
                       key={item.value}
                       style={{
                         fontSize: '12px',
-                        color: '#464343',
                         display: 'flex',
                         alignItems: 'center',
                         cursor: 'pointer',
@@ -1294,8 +1293,8 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
                       aria-pressed="false"
                       className={
                         this.state.styles.align === 'left'
-                          ? 'czi-custom-button use-icon molsp-activealignbuttons'
-                          : 'czi-custom-button molsp-alignbuttons'
+                          ? 'czi-custom-button use-icon molsp-activealignbuttons ' + this.props.theme
+                          : 'czi-custom-button molsp-alignbuttons ' + this.props.theme
                       }
                       onClick={this.onAlignButtonClick.bind(this, 'left')}
                     >
@@ -1316,8 +1315,8 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
                       aria-pressed="false"
                       className={
                         this.state.styles.align === 'center'
-                          ? 'czi-custom-button use-icon molsp-activealignbuttons'
-                          : 'czi-custom-button  molsp-alignbuttons'
+                          ? 'czi-custom-button use-icon molsp-activealignbuttons '+ this.props.theme
+                          : 'czi-custom-button  molsp-alignbuttons '+ this.props.theme
                       }
                       onClick={this.onAlignButtonClick.bind(this, 'center')}
                     >
@@ -1338,8 +1337,8 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
                       aria-pressed="false"
                       className={
                         this.state.styles.align === 'right'
-                          ? 'czi-custom-button use-icon molsp-activealignbuttons'
-                          : 'czi-custom-button  molsp-alignbuttons'
+                          ? 'czi-custom-button use-icon molsp-activealignbuttons '+ this.props.theme
+                          : 'czi-custom-button  molsp-alignbuttons '+ this.props.theme
                       }
                       onClick={this.onAlignButtonClick.bind(this, 'right')}
                     >
@@ -1360,8 +1359,8 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
                       aria-pressed="false"
                       className={
                         this.state.styles.align === 'justify'
-                          ? 'czi-custom-button use-icon molsp-activealignbuttons'
-                          : 'czi-custom-button  molsp-alignbuttons'
+                          ? 'czi-custom-button use-icon molsp-activealignbuttons '+ this.props.theme
+                          : 'czi-custom-button  molsp-alignbuttons '+ this.props.theme
                       }
                       onClick={this.onAlignButtonClick.bind(this, 'justify')}
                     >
@@ -1475,7 +1474,15 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
                           type="radio"
                           value="userDefined"
                         />
+                        <span
+                          style={{
+                            marginLeft: '2px',
+                            position: 'relative',
+                            top: '-2px',
+                          }}
+                        >
                         User-defined Numbering/Bullets
+                        </span>
                       </label>
                       <br />
                       <label>
@@ -1491,7 +1498,15 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
                           type="radio"
                           value="listStyle"
                         />
+                        <span
+                          style={{
+                            marginLeft: '2px',
+                            position: 'relative',
+                            top: '-2px',
+                          }}
+                        >
                         List-style (Auto Numbering)
+                        </span>
                       </label>
                     </div>
                   </div>

--- a/src/ui/CustomstyleDropDownCommand.tsx
+++ b/src/ui/CustomstyleDropDownCommand.tsx
@@ -171,13 +171,11 @@ export class CustomstyleDropDownCommand extends React.PureComponent<{
           editorState={editorState}
           editorView={editorView}
           label={customStyleName}
+          title={customStyleName}
           staticCommand={this.staticCommands(
             toCreateStyle ? customStyleName : ''
           )}
         />
-        <span className="custom-tooltip">
-          <span className="tooltip-text">{customStyleName}</span>
-        </span>
       </span>
     );
   }

--- a/src/ui/custom-dropdown.css
+++ b/src/ui/custom-dropdown.css
@@ -81,13 +81,11 @@
 }
 
 #container1:hover {
-  background-color: var(--czi-button-hover-background-color);
   border: 1px solid;
   border-radius: 6px;
 }
 
 .selectbackground {
-  background-color: var(--czi-button-hover-background-color);
   border: 1px solid;
   border-radius: 6px;
 }

--- a/src/ui/custom-style-edit.css
+++ b/src/ui/custom-style-edit.css
@@ -284,7 +284,7 @@
   margin-top: -1px;
 }
 
-.czi-editor-frameset .molsp-alignbuttons {
+.czi-editor-frameset .czi-custom-button.molsp-alignbuttons.light {
   background-color: #f0f0f0;
   border-color: #555;
   outline: none;
@@ -292,10 +292,19 @@
   text-align: center;
   width: 50px;
   border-radius: 0px;
+  color:#666
 }
-
-.czi-editor-frameset .molsp-alignbuttons:focus,
-.czi-editor-frameset .molsp-alignbuttons:hover {
+.czi-editor-frameset .czi-custom-button.molsp-alignbuttons.dark {
+  background-color: transparent;
+  border-color: #555;
+  outline: none;
+  padding: 0;
+  text-align: center;
+  width: 50px;
+  border-radius: 0px;
+}
+.czi-editor-frameset .czi-custom-button.molsp-alignbuttons:focus,
+.czi-editor-frameset .czi-custom-button.molsp-alignbuttons:hover {
   background-color: #f0f0f0;
   border-color: #338eec;
   outline: none;
@@ -309,6 +318,12 @@
   width: 50px;
   border-radius: 0px;
 }
+
+.czi-editor-frameset .czi-custom-button.molsp-activealignbuttons:focus,
+.czi-editor-frameset .czi-custom-button.molsp-activealignbuttons:hover {
+  background-color: transparent;
+}
+
 
 .czi-editor-frameset .molsp-panel.hr {
   margin-bottom: 0;

--- a/src/ui/icon-font.css
+++ b/src/ui/icon-font.css
@@ -4,6 +4,6 @@ Now loaded locally, so that it work in closed network as well. */
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: local('Material Icons'), local('MaterialIcons-Regular');
-  /* url('../assets/fonts/material-icons/MaterialIcons-Regular.ttf') format('truetype'); */
+  src: local('Material Icons'), local('MaterialIcons-Regular')
+  url('../assets/fonts/material-icons/MaterialIcons-Regular.ttf') format('truetype');
 }


### PR DESCRIPTION
1. Fixed UI issues in Style editor
(Alignment buttons appear same in both light and dark modes, the button content is not visible, and a dark background appears when hovering over style names in the style dropdown as well as on the selected style.)
2. In the Custom Style editor, TOC, TOT, TOF, and NONE labels are not visible.
3. In the Custom Style editor, Hanging Indent UI is broken
4. The Custom Style tooltip should match other toolbar button tooltips