### PR TITLE
Hide CAPCO gets deselected when switching between None/TOC/Table/Figure is fixed now.

### DIFF
--- a/src/ui/CustomStyleEditor.tsx
+++ b/src/ui/CustomStyleEditor.tsx
@@ -455,7 +455,7 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
       styles: {
         ...prevState.styles,
         styleLevel: level,
-        hideCapco: isCheckboxDisabled ? false : prevState.styles.hideCapco,
+        hideCapco: prevState.styles.hideCapco,
         contNumber:
           isCheckboxDisabled || level !== 2 ? false : prevState.styles.contNumber,
         hasNumbering: isCheckboxDisabled
@@ -710,7 +710,7 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
         tot: false,
         tof: false,
         prefixValue: '',
-        hideCapco: false,
+        hideCapco: prevState.styles.hideCapco,
         contNumber: false,
         hasNumbering: false,
         nextLineStyleName: RESERVED_STYLE_NONE,
@@ -728,7 +728,7 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
         tot: false,
         tof: false,
         prefixValue: '',
-        hideCapco: false,
+        hideCapco: prevState.styles.hideCapco,
         contNumber: false,
         hasNumbering: false,
         styleLevel: 0,
@@ -746,7 +746,7 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
         tot: val.target.checked,
         tof: false,
         prefixValue: val.target.checked ? 'TABLE ' : '',
-        hideCapco: false,
+        hideCapco: prevState.styles.hideCapco,
         contNumber: false,
         hasNumbering: val.target.checked,
         nextLineStyleName: val.target.checked
@@ -766,7 +766,7 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
         tot: false,
         tof: val.target.checked,
         prefixValue: val.target.checked ? 'FIGURE ' : '',
-        hideCapco: false,
+        hideCapco: prevState.styles.hideCapco,
         contNumber: false,
         hasNumbering: val.target.checked,
         nextLineStyleName: val.target.checked
@@ -791,7 +791,7 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
           ...prevState.styles,
           styleLevel,
           isList,
-          hideCapco: isList ? false : prevState.styles.hideCapco,
+          hideCapco: prevState.styles.hideCapco,
           contNumber: isList ? false : prevState.styles.contNumber,
         },
         isRadioDisabled: styleLevel === 0,
@@ -938,7 +938,6 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
   }
 
   render() {
-    const capcoOptionsDisabled = this.isCapcoOptionDisabled();
     const numberingOptionsDisabled = this.isNumberingOptionDisabled();
     const contNumberDisabled = this.isContNumberDisabled();
 
@@ -1380,7 +1379,6 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
                   >
                     <input
                       checked={this.state.styles.hideCapco}
-                      disabled={capcoOptionsDisabled}
                       onChange={this.handleHideCapco.bind(this)}
                       type="checkbox"
                     />
@@ -2299,13 +2297,6 @@ export class CustomStyleEditor extends React.PureComponent<any, any> {
       this.state.styles.styleLevel === 0 ||
       this.state.styles.styleLevel === undefined ||
       (this.state.styles.styleLevel === 1 && this.state.styles.isList === true)
-    );
-  }
-
-  isCapcoOptionDisabled() {
-    return (
-      this.state.styles.isList === true ||
-      this.state.styleName === RESERVED_STYLE_NONE
     );
   }
 

--- a/src/ui/customStyleEditor.test.ts
+++ b/src/ui/customStyleEditor.test.ts
@@ -158,7 +158,7 @@ describe('CustomStyleEditor', () => {
   });
   describe('onFontNameChange', () => {
     // //FSFIX    Breakthrough code to cover code inside setState
-    let component;
+    let component: CustomStyleEditor;
 
     beforeEach(() => {
       // Initialize the component
@@ -371,24 +371,8 @@ describe('CustomStyleEditor', () => {
       otherStyleSelected: '',
     };
 
-    expect(customstyleeditor.isCapcoOptionDisabled()).toBe(false);
     expect(customstyleeditor.isNumberingOptionDisabled()).toBe(true);
     expect(customstyleeditor.isContNumberDisabled()).toBe(true);
-  });
-  it('should allow Hide Capco when style level is none', () => {
-    customstyleeditor.state = {
-      styles: {
-        align: 'left',
-        hideCapco: false,
-        styleLevel: 0,
-        isList: false,
-      },
-      mode: 0,
-      styleName: 'A Apply Stylefff',
-      otherStyleSelected: '',
-    };
-
-    expect(customstyleeditor.isCapcoOptionDisabled()).toBe(false);
   });
   it('should allow Continue Numbering only for table and figure styles', () => {
     customstyleeditor.state = {


### PR DESCRIPTION
Hide CAPCO gets deselected when switching between None/TOC/Table/Figure is fixed now.